### PR TITLE
Fixed a bug when creating a new note with alt+N without leaving the editing box of the current note; changes to the current note were not saved.

### DIFF
--- a/addon/globalPlugins/noteManager.py
+++ b/addon/globalPlugins/noteManager.py
@@ -350,6 +350,7 @@ class NotesDialog(
 		self.updateSelection()
 
 	def onNewNote(self, evt):
+		self.onNoteUpdate(evt)
 		newIndex = len(self.addon.notes)
 		self.searches[""] = newIndex
 		self.addon.notes.append("")


### PR DESCRIPTION
When you are writing a new note or modifying an existing note if, without leaving the edit box, you press Alt+N to create a new note, the changes to the note you were working on are not saved.
This fix saves changes to the current note before creating a new one.