### PR TITLE
Deletes all selected notes in the list at once.

### DIFF
--- a/addon/globalPlugins/noteManager.py
+++ b/addon/globalPlugins/noteManager.py
@@ -360,12 +360,14 @@ class NotesDialog(
 		self.currentNoteField.SetFocus()
 
 	def onDelete(self, evt):
-		if len(self.selection) > 1 or len(self.searchNotes) == 0:
+		if not self.selection or len(self.searchNotes) == 0:
 			return
-		curIndex = self.noteList.GetFocusedItem()
-		nIndex = self.searchNotes[curIndex][0]
-		self.addon.removeNote(nIndex)
-		self.addon.save()
+		deletedItems = 0
+		for selected in sorted(self.selection):
+			nIndex = self.searchNotes[selected][0]-deletedItems
+			self.addon.removeNote(nIndex)
+			deletedItems = deletedItems+1
+		self.addon.save()	
 		self.onSearch(None, self.curSearch)
 
 	def onNoteUpdate(self, evt=None):


### PR DESCRIPTION
When more than one note is selected in the list the delete note command does nothing.
With this modification it is allowed to delete several notes at once. By pressing the button ddelete note or the keyboard shortcut alt+L all the selected notes in the list will be deleted.
You might consider implementing a confirmation dialog for this. It has not been included in this commit.